### PR TITLE
Normalize values before rehydration

### DIFF
--- a/src/formik-persist.tsx
+++ b/src/formik-persist.tsx
@@ -7,6 +7,7 @@ export interface PersistProps {
   name: string;
   debounce?: number;
   isSessionStorage?: boolean;
+  normalize?: (values: any) => any;
 }
 
 class PersistImpl extends React.Component<
@@ -15,6 +16,7 @@ class PersistImpl extends React.Component<
 > {
   static defaultProps = {
     debounce: 300,
+    normalize: (values) => values,
   };
 
   saveForm = debounce((data: FormikProps<{}>) => {
@@ -36,7 +38,7 @@ class PersistImpl extends React.Component<
       ? window.sessionStorage.getItem(this.props.name)
       : window.localStorage.getItem(this.props.name);
     if (maybeState && maybeState !== null) {
-      this.props.formik.setFormikState(JSON.parse(maybeState));
+      this.props.formik.setFormikState(this.props.normalize(JSON.parse(maybeState)));
     }
   }
 


### PR DESCRIPTION
The normalize prop would help people with special values, for example Moment instances that turn into a date string after JSON.stringify, to normalize their data before it is re-populated in formik with invalid values.